### PR TITLE
Corrections for X# Version 2.19.2

### DIFF
--- a/src/XSharp.VsParser.Helpers.Tests/Rewriter/ConstructorContextTests.cs
+++ b/src/XSharp.VsParser.Helpers.Tests/Rewriter/ConstructorContextTests.cs
@@ -61,6 +61,32 @@ return nil");
         }
 
         [Fact]
+        public void DeleteAllParametersTest()
+        {
+            var code = WrapInClass(@"Constructor(test)
+return nil");
+
+            var expected = WrapInClass(@"Constructor()
+return nil");
+
+            Rewrite(code, expected, r => r.DeleteAllParameters());
+        }
+
+        [Fact]
+        public void DeleteAllParametersWithNoParametersTest()
+        {
+            var code = WrapInClass(@"Constructor()
+super()
+return nil");
+
+            var expected = WrapInClass(@"Constructor()
+super()
+return nil");
+
+            Rewrite(code, expected, r => r.DeleteAllParameters());
+        }
+
+        [Fact]
         public void ReplaceParametersEmptyTest()
         {
             var code = WrapInClass(@"Constructor ()

--- a/src/XSharp.VsParser.Helpers.Tests/Rewriter/ConstructorchainContextTests.cs
+++ b/src/XSharp.VsParser.Helpers.Tests/Rewriter/ConstructorchainContextTests.cs
@@ -21,6 +21,16 @@ namespace XSharp.Parser.Helpers.Tests.Rewriter
         }
 
         [Fact]
+        public void DeleteAllParametersNoParametersTest()
+        {
+            var code = WrapInConstructor(@"super()");
+
+            var expected = WrapInConstructor(@"super()");
+
+            Rewrite(code, expected, r => r.DeleteAllArguments());
+        }
+
+        [Fact]
         public void ReplaceAllParametersTest()
         {
             var code = WrapInConstructor(@"super(1, 2, 3)");

--- a/src/XSharp.VsParser.Helpers.Tests/Rewriter/MethodCallContextTests.cs
+++ b/src/XSharp.VsParser.Helpers.Tests/Rewriter/MethodCallContextTests.cs
@@ -30,11 +30,20 @@ namespace XSharp.Parser.Helpers.Tests.Rewriter
             Rewrite(code, expected, r => r.ReplaceNameExpression("NewDummy"));
         }
 
-
         [Fact]
         public void DeleteAllArgumentsTest()
         {
             var code = WrapInMethod(@"self:Dummy(null_object)");
+
+            var expected = WrapInMethod(@"self:Dummy()");
+
+            Rewrite(code, expected, r => r.DeleteAllArguments());
+        }
+
+        [Fact]
+        public void DeleteAllArgumentsNoArgumentsTest()
+        {
+            var code = WrapInMethod(@"self:Dummy()");
 
             var expected = WrapInMethod(@"self:Dummy()");
 

--- a/src/XSharp.VsParser.Helpers.Tests/Rewriter/MethodContextTests.cs
+++ b/src/XSharp.VsParser.Helpers.Tests/Rewriter/MethodContextTests.cs
@@ -167,6 +167,30 @@ return nil");
         }
 
         [Fact]
+        public void DeleteAllParametersTest()
+        {
+            var code = WrapInClass(@"method Dummy(test) as void
+return nil");
+
+            var expected = WrapInClass(@"method Dummy() as void
+return nil");
+
+            Rewrite(code, expected, r => r.DeleteAllParameters());
+        }
+
+        [Fact]
+        public void DeleteAllParametersWithNoParametersTest()
+        {
+            var code = WrapInClass(@"method Dummy() as void
+return nil");
+
+            var expected = WrapInClass(@"method Dummy() as void
+return nil");
+
+            Rewrite(code, expected, r => r.DeleteAllParameters());
+        }
+
+        [Fact]
         public void ReplaceParametersEmptyTest()
         {
             var code = WrapInClass(@"method Dummy()

--- a/src/XSharp.VsParser.Helpers/Parser/Values/ParameterContextValues.cs
+++ b/src/XSharp.VsParser.Helpers/Parser/Values/ParameterContextValues.cs
@@ -35,5 +35,10 @@ namespace XSharp.VsParser.Helpers.Parser.Values
                 Default = context.Default?.GetText(),
             };
         }
+
+        static internal bool IsEmpty(ParameterContext context)
+        {
+            return context == null || string.IsNullOrWhiteSpace(context.identifier()?.GetText());
+        }
     }
 }

--- a/src/XSharp.VsParser.Helpers/Parser/Values/SignatureContextValues.cs
+++ b/src/XSharp.VsParser.Helpers/Parser/Values/SignatureContextValues.cs
@@ -43,5 +43,10 @@ namespace XSharp.VsParser.Helpers.Parser.Values
                 Parameters = (context.parameterList()?.AsEnumerable().WhereType<ParameterContext>().ToValues() ?? Enumerable.Empty<ParameterContextValues>()).ToArray(),
             };
         }
+
+        static internal bool IsParamListEmpty(ParameterListContext context)
+        {
+            return context?._Params == null || context._Params.Count == 0 || context._Params.All(q => ParameterContextValues.IsEmpty(q));
+        }
     }
 }

--- a/src/XSharp.VsParser.Helpers/Project/ProjectHelper.cs
+++ b/src/XSharp.VsParser.Helpers/Project/ProjectHelper.cs
@@ -91,7 +91,7 @@ namespace XSharp.VsParser.Helpers.Project
 
 
         private string GetProjectProperty(string propertyName)
-            => _ProjectXml.Root.Element(_Ns + "PropertyGroup").Element(_Ns + propertyName)?.Value;
+            => _ProjectXml.Root.Element(_Ns + "PropertyGroup").ElementIgnoreCase(propertyName)?.Value;
 
         /// <summary>
         /// Gets all the references and project references
@@ -134,5 +134,24 @@ namespace XSharp.VsParser.Helpers.Project
             return result;
         }
 
+    }
+
+    /// <summary>
+    /// XElementExtensions
+    /// </summary>
+    internal static class XElementExtensions
+    {
+        /// <summary>
+        /// ElementIgnoreCase
+        /// </summary>
+        /// <param name="element"></param>
+        /// <param name="localName"></param>
+        /// <returns></returns>
+        public static XElement ElementIgnoreCase(this XElement element, string localName)
+        {
+            return element.Elements()
+                .FirstOrDefault(x =>
+                    string.Equals(x.Name.LocalName, localName, StringComparison.OrdinalIgnoreCase));
+        }
     }
 }

--- a/src/XSharp.VsParser.Helpers/Rewriter/InternalRewriterHelper.cs
+++ b/src/XSharp.VsParser.Helpers/Rewriter/InternalRewriterHelper.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using XSharp.VsParser.Helpers.Parser;
+using XSharp.VsParser.Helpers.Parser.Values;
 using static LanguageService.CodeAnalysis.XSharp.SyntaxParser.XSharpParser;
 
 namespace XSharp.VsParser.Helpers.Rewriter
@@ -31,7 +32,7 @@ namespace XSharp.VsParser.Helpers.Rewriter
 
         public static void DeleteAllParameters(TokenStreamRewriter rewriter, ParameterListContext paramList)
         {
-            if ((paramList?._Params?.Count ?? 0) > 0)
+            if (!SignatureContextValues.IsParamListEmpty(paramList))
                 rewriter.Replace(paramList.Start.ToIndex(), paramList.Stop.ToIndex(), "()");
         }
 
@@ -59,5 +60,6 @@ namespace XSharp.VsParser.Helpers.Rewriter
                 return $"as {type}";
             return type;
         }
+
     }
 }

--- a/src/XSharp.VsParser.Helpers/Rewriter/RewriterForConstructorchainExtensions.cs
+++ b/src/XSharp.VsParser.Helpers/Rewriter/RewriterForConstructorchainExtensions.cs
@@ -20,7 +20,7 @@ namespace XSharp.VsParser.Helpers.Rewriter
         public static RewriterForContext<ConstructorchainContext> DeleteAllArguments(this RewriterForContext<ConstructorchainContext> rewriterFor)
         {
             var argList = rewriterFor.Context.ArgList;
-            if ((argList?.ChildCount ?? 0) == 0)
+            if (MethodCallContextValues.IsArgListEmpty(argList))
                 return rewriterFor;
 
             rewriterFor.Rewriter.Delete(argList.Start.ToIndex(), argList.Stop.ToIndex());

--- a/src/XSharp.VsParser.Helpers/Rewriter/RewriterForMethodCallExtensions.cs
+++ b/src/XSharp.VsParser.Helpers/Rewriter/RewriterForMethodCallExtensions.cs
@@ -20,10 +20,11 @@ namespace XSharp.VsParser.Helpers.Rewriter
         public static RewriterForContext<MethodCallContext> DeleteAllArguments(this RewriterForContext<MethodCallContext> rewriterFor)
         {
             var argList = rewriterFor.Context.ArgList;
-            if ((argList?.ChildCount ?? 0) == 0)
+            if (MethodCallContextValues.IsArgListEmpty(argList))
                 return rewriterFor;
 
             rewriterFor.Rewriter.Delete(argList.Start.ToIndex(), argList.Stop.ToIndex());
+
             return rewriterFor;
         }
 

--- a/src/XSharp.VsParser.Helpers/XSharp.VsParser.Helpers.csproj
+++ b/src/XSharp.VsParser.Helpers/XSharp.VsParser.Helpers.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<TargetFramework>netstandard2.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
-		<Version>24.18.0.0</Version>
+		<Version>24.18.8.0</Version>
 		<Authors>Volkmar Rigo, Hansjoerg Petriffer</Authors>
 		<Company>Infominds AG</Company>
 		<Product>XSharp.VsParser.Helpers</Product>


### PR DESCRIPTION
- case insensitive reading of project file properties
- Some exception with no args in methods and constructor